### PR TITLE
Fix an annoying cbase rebalance failure issue by backporting an upstream fix.

### DIFF
--- a/cbase/memcached/memcached-1.4.4/daemon/memcached.c
+++ b/cbase/memcached/memcached-1.4.4/daemon/memcached.c
@@ -920,6 +920,10 @@ static int add_iov(conn *c, const void *buf, int len) {
 
     assert(c != NULL);
 
+    if (len == 0) {
+        return 0;
+    }
+
     do {
         m = &c->msglist[c->msgused - 1];
 
@@ -1446,9 +1450,7 @@ static void write_bin_packet(conn *c, protocol_binary_response_status err, int s
     }
 
     add_bin_header(c, err, 0, 0, len);
-    if (len > 0) {
-        add_iov(c, buffer, len);
-    }
+    add_iov(c, buffer, len);
     conn_set_state(c, conn_mwrite);
     if (swallow > 0) {
         c->sbytes = swallow;
@@ -1463,9 +1465,7 @@ static void write_bin_response(conn *c, void *d, int hlen, int keylen, int dlen)
     if (!c->noreply || c->cmd == PROTOCOL_BINARY_CMD_GET ||
         c->cmd == PROTOCOL_BINARY_CMD_GETK) {
         add_bin_header(c, 0, hlen, keylen, dlen);
-        if(dlen > 0) {
-            add_iov(c, d, dlen);
-        }
+        add_iov(c, d, dlen);
         conn_set_state(c, conn_mwrite);
         c->write_and_go = conn_new_cmd;
     } else {
@@ -2224,9 +2224,7 @@ static void process_bin_complete_sasl_auth(conn *c) {
         break;
     case SASL_CONTINUE:
         add_bin_header(c, PROTOCOL_BINARY_RESPONSE_AUTH_CONTINUE, 0, 0, outlen);
-        if(outlen > 0) {
-            add_iov(c, out, outlen);
-        }
+        add_iov(c, out, outlen);
         conn_set_state(c, conn_mwrite);
         c->write_and_go = conn_new_cmd;
         break;
@@ -5020,11 +5018,12 @@ bool update_event(conn *c, const int new_flags) {
 static enum transmit_result transmit(conn *c) {
     assert(c != NULL);
 
-    if (c->msgcurr < c->msgused &&
-            c->msglist[c->msgcurr].msg_iovlen == 0) {
+    while (c->msgcurr < c->msgused &&
+           c->msglist[c->msgcurr].msg_iovlen == 0) {
         /* Finished writing the current msg; advance to the next. */
         c->msgcurr++;
     }
+
     if (c->msgcurr < c->msgused) {
         ssize_t res;
         struct msghdr *m = &c->msglist[c->msgcurr];

--- a/cbase/memcached/memcached-1.4.4/daemon/memcached.c
+++ b/cbase/memcached/memcached-1.4.4/daemon/memcached.c
@@ -4946,6 +4946,8 @@ static enum try_read_result try_read_network(conn *c) {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
                 break;
             }
+	    settings.extensions.logger->log(EXTENSION_LOG_WARNING, c,
+	                                    "%d Closing connection due to read error: %s", c->sfd, strerror(errno));
             return READ_ERROR;
         }
     }
@@ -5328,8 +5330,8 @@ bool conn_swallow(conn *c) {
     if (errno != ENOTCONN && errno != ECONNRESET) {
         /* otherwise we have a real error, on which we close the connection */
         settings.extensions.logger->log(EXTENSION_LOG_INFO, c,
-                                        "Failed to read, and not due to blocking (%s)\n",
-                                        strerror(errno));
+                                        "%d Failed to read, and not due to blocking (%s)\n",
+                                        c->sfd, strerror(errno));
     }
 
     conn_set_state(c, conn_closing);
@@ -5396,10 +5398,10 @@ bool conn_nread(conn *c) {
     if (errno != ENOTCONN && errno != ECONNRESET) {
         /* otherwise we have a real error, on which we close the connection */
         settings.extensions.logger->log(EXTENSION_LOG_WARNING, c,
-                                        "Failed to read, and not due to blocking:\n"
+                                        "%d Failed to read, and not due to blocking:\n"
                                         "errno: %d %s \n"
                                         "rcurr=%lx ritem=%lx rbuf=%lx rlbytes=%d rsize=%d\n",
-                                        errno, strerror(errno),
+                                        c->sfd, errno, strerror(errno),
                                         (long)c->rcurr, (long)c->ritem, (long)c->rbuf,
                                         (int)c->rlbytes, (int)c->rsize);
     }


### PR DESCRIPTION
See the upstream git log below for the details.

commit 85b8b7f569a8cc4130701e47291e2707aefa461e
Author: Trond Norbye <trond.norbye@gmail.com>
Date:   Mon Jul 23 10:44:51 2012 +0200

    Ignore empty chunks in call to add_iov

    We've discovered that we may try to call sendmsg with an empty chunk
    causing sendmsg to return 0 and we treat that as an error and close
    the connection.

    Change-Id: I475aeb5b51f4cfc6a32348a4e912c8b86707c3ef
    Reviewed-on: http://review.couchbase.org/19024
    Reviewed-by: Matt Ingenthron <matt@couchbase.com>
    Tested-by: Trond Norbye <trond.norbye@gmail.com>